### PR TITLE
SimpleDB: implement domain_metadata

### DIFF
--- a/moto/sdb/models.py
+++ b/moto/sdb/models.py
@@ -100,5 +100,30 @@ class SimpleDBBackend(BaseBackend):
         domain = self._get_domain(domain_name)
         domain.put(item_name, attributes)
 
+    def domain_metadata(self, domain_name: str) -> dict[str, Any]:
+        self._validate_domain_name(domain_name)
+        domain = self._get_domain(domain_name)
+        item_names_size_bytes = 0
+        attribute_name_count = 0
+        attribute_names_size_bytes = 0
+        attribute_value_count = 0
+        attribute_values_size_bytes = 0
+        for name, item in domain.items.items():
+            item_names_size_bytes += len(name)
+            with item.lock:
+                for attr in item.attributes:
+                    attribute_name_count += 1
+                    attribute_names_size_bytes += len(attr["Name"])
+                    attribute_value_count += 1
+                    attribute_values_size_bytes += len(attr["Value"])
+        return {
+            "item_count": len(domain.items),
+            "item_names_size_bytes": item_names_size_bytes,
+            "attribute_name_count": attribute_name_count,
+            "attribute_names_size_bytes": attribute_names_size_bytes,
+            "attribute_value_count": attribute_value_count,
+            "attribute_values_size_bytes": attribute_values_size_bytes,
+        }
+
 
 sdb_backends = BackendDict(SimpleDBBackend, "sdb")

--- a/moto/sdb/responses.py
+++ b/moto/sdb/responses.py
@@ -39,11 +39,78 @@ class SimpleDBResponse(BaseResponse):
         result = {"Attributes": attributes}
         return ActionResult(result)
 
-    def put_attributes(self) -> ActionResult:
+    def put_attributes(self) -> str:
         domain_name = self._get_param("DomainName")
         item_name = self._get_param("ItemName")
         attributes = self._get_param("Attributes")
         self.sdb_backend.put_attributes(
             domain_name=domain_name, item_name=item_name, attributes=attributes
         )
-        return EmptyResult()
+        template = self.response_template(PUT_ATTRIBUTES_TEMPLATE)
+        return template.render()
+
+    def domain_metadata(self) -> str:
+        domain_name = self._get_param("DomainName")
+        metadata = self.sdb_backend.domain_metadata(domain_name=domain_name)
+        template = self.response_template(DOMAIN_METADATA_TEMPLATE)
+        return template.render(metadata=metadata)
+
+
+CREATE_DOMAIN_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<CreateDomainResult  xmlns="http://sdb.amazonaws.com/doc/2009-04-15/"></CreateDomainResult>
+"""
+
+
+LIST_DOMAINS_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<ListDomainsResponse  xmlns="http://sdb.amazonaws.com/doc/2009-04-15/">
+    <ListDomainsResult>
+        {% for name in domain_names %}
+            <DomainName>{{ name }}</DomainName>
+        {% endfor %}
+        <NextToken>{{ next_token }}</NextToken>
+    </ListDomainsResult>
+</ListDomainsResponse>
+"""
+
+DELETE_DOMAIN_TEMPLATE = """<?xml version="1.0"?>
+<DeleteDomainResponse xmlns="http://sdb.amazonaws.com/doc/2009-04-15/">
+  <ResponseMetadata>
+    <RequestId>64d9c3ac-ef19-2e3d-7a03-9ea46205eb71</RequestId>
+    <BoxUsage>0.0055590278</BoxUsage>
+  </ResponseMetadata>
+</DeleteDomainResponse>"""
+
+PUT_ATTRIBUTES_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
+<PutAttributesResult xmlns="http://sdb.amazonaws.com/doc/2009-04-15/"></PutAttributesResult>
+"""
+
+GET_ATTRIBUTES_TEMPLATE = """<GetAttributesResponse xmlns="http://sdb.amazonaws.com/doc/2009-04-15/">
+  <ResponseMetadata>
+    <RequestId>1549581b-12b7-11e3-895e-1334aEXAMPLE</RequestId>
+  </ResponseMetadata>
+  <GetAttributesResult>
+{% for attribute in attributes %}
+      <Attribute>
+        <Name>{{ attribute["name"] }}</Name>
+        <Value>{{ attribute["value"] }}</Value>
+      </Attribute>
+{% endfor %}
+  </GetAttributesResult>
+</GetAttributesResponse>"""
+
+
+DOMAIN_METADATA_TEMPLATE = """<DomainMetadataResponse xmlns="http://sdb.amazonaws.com/doc/2009-04-15/">
+  <DomainMetadataResult>
+    <ItemCount>{{ metadata.item_count }}</ItemCount>
+    <ItemNamesSizeBytes>{{ metadata.item_names_size_bytes }}</ItemNamesSizeBytes>
+    <AttributeNameCount >{{ metadata.attribute_name_count }}</AttributeNameCount >
+    <AttributeNamesSizeBytes>{{ metadata.attribute_names_size_bytes }}</AttributeNamesSizeBytes>
+    <AttributeValueCount>{{ metadata.attribute_value_count }}</AttributeValueCount>
+    <AttributeValuesSizeBytes>{{ metadata.attribute_values_size_bytes }}</AttributeValuesSizeBytes>
+    <Timestamp>1225486466</Timestamp>
+  </DomainMetadataResult>
+  <ResponseMetadata>
+    <RequestId>b1e8f1f7-42e9-494c-ad09-2674e557526d</RequestId>
+    <BoxUsage>0.0000219907</BoxUsage>
+  </ResponseMetadata>
+</DomainMetadataResponse>"""

--- a/tests/test_sdb/test_sdb_domains.py
+++ b/tests/test_sdb/test_sdb_domains.py
@@ -1,3 +1,5 @@
+from unittest.mock import ANY
+
 import boto3
 import pytest
 from botocore.exceptions import ClientError
@@ -65,3 +67,25 @@ def test_delete_domain_invalid():
     assert err["Code"] == "InvalidParameterValue"
     assert err["Message"] == "Value (a) for parameter DomainName is invalid. "
     assert "BoxUsage" in err
+
+
+@mock_aws
+def test_domain_metadata():
+    name = "mydomain"
+    sdb = boto3.client("sdb", region_name="eu-west-1")
+    sdb.create_domain(DomainName=name)
+    sdb.put_attributes(
+        DomainName=name, ItemName="asdf", Attributes=[{"Name": "abc", "Value": "de"}]
+    )
+    metadata = sdb.domain_metadata(DomainName=name)
+    expected = {
+        "ItemCount": 1,
+        "ItemNamesSizeBytes": 4,
+        "AttributeNameCount": 1,
+        "AttributeNamesSizeBytes": 3,
+        "AttributeValueCount": 1,
+        "AttributeValuesSizeBytes": 2,
+        "Timestamp": ANY,
+        "ResponseMetadata": ANY,
+    }
+    assert metadata == expected


### PR DESCRIPTION
This PR implements the [SimpleDB.Client.domain_metadata](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/sdb/client/domain_metadata.html) method.